### PR TITLE
allow async mock to take async function as side effect

### DIFF
--- a/nextmock/async_mock.py
+++ b/nextmock/async_mock.py
@@ -1,7 +1,12 @@
+import inspect
+
 from .mock import Mock
 
 
 class AsyncMock(Mock):
 
     async def __call__(self, *args, **kwargs):
-        return super().__call__(*args, **kwargs)
+        result = super().__call__(*args, **kwargs)
+        if inspect.iscoroutine(result):
+            result = await result
+        return result

--- a/nextmock/test/test_async_mock.py
+++ b/nextmock/test/test_async_mock.py
@@ -10,3 +10,13 @@ class TestAsyncMock:
         m = AsyncMock()
         m.with_args(1, a=1).returns(123)
         assert await m(1, a=1) == 123
+
+    @pytest.mark.asyncio
+    async def test_async_mock_side_effect_can_take_async_function(self):
+        m = AsyncMock()
+
+        async def side_effect():
+            return 123
+
+        m.side_effect = side_effect
+        assert await m() == 123


### PR DESCRIPTION
The AsyncMock object will fail when taking async side effect because the result after called is a coroutine object. This pull request may allows the scenario when we would like to give the mock object async function as side effect.