### PR TITLE
fix enum as args should match value instead of object

### DIFF
--- a/nextmock/fake.py
+++ b/nextmock/fake.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Any, Optional
 
 from .arg import Arg
@@ -61,7 +62,7 @@ class Fake:
         return self._match_value(arg1, arg2)
 
     def _is_object(self, arg: Any) -> bool:
-        return hasattr(arg, "__dict__")
+        return hasattr(arg, "__dict__") and not isinstance(arg, Enum)
 
     def _match_object(self, arg1: Any, arg2: Any) -> bool:
         if not (self._is_object(arg1) and self._is_object(arg2)):

--- a/nextmock/test/test_mock_with_args.py
+++ b/nextmock/test/test_mock_with_args.py
@@ -1,5 +1,6 @@
 import pytest
 
+from enum import Enum
 from typing import List
 
 from ..arg import Arg
@@ -229,3 +230,14 @@ class TestMockWithArgs:
         assert m(a=1, b=2, c=1) == 123
         assert m(a=1, b=2, c=9) == 123
         assert m(a=1, b=2, c="123") == 123
+
+    # enum
+
+    class Category(Enum):
+        A = "a"
+        B = "b"
+
+    def test_with_args_should_return_fake_result_when_enum_args_matched(self):
+        m = Mock()
+        m.with_args(self.Category.A).returns(123)
+        assert m(self.Category.A) == 123


### PR DESCRIPTION
In Fake object, matching enum by object will cause infinite recursion. This pull request match enum by value, which fixes the bug of enum arguments comparison.