### PR TITLE
fix mock will return none when given zero value

### DIFF
--- a/nextmock/fake.py
+++ b/nextmock/fake.py
@@ -51,7 +51,7 @@ class Fake:
         return True
 
     def _execute(self) -> Any:
-        if self._result:
+        if self._result is not None:
             return self._result
         if self._exception:
             raise self._exception

--- a/nextmock/test/test_mock_returns.py
+++ b/nextmock/test/test_mock_returns.py
@@ -8,3 +8,9 @@ class TestMockReturns:
         m.returns(123)
         assert m() == 123
         assert m(1, 2, 3) == 123
+
+    def test_returns_when_given_zero_value(self):
+        m = Mock()
+        m.returns(0)
+        assert m() == 0
+        assert m(1, 2, 3) == 0


### PR DESCRIPTION
Hi pilagod,
I found that the Mock object would return "None" when it was given zero value, and I think the cause is python evaluates "0" as false in the "if" condition. I try to fix it in this pull request, and a unit test is added.